### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/mgood/tuisage/compare/v0.1.2...v0.1.3) - 2026-03-23
+
+### Other
+
+- add notes on binary installation
+
 ## [0.1.2](https://github.com/mgood/tuisage/compare/v0.1.1...v0.1.2) - 2026-03-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "tuisage"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuisage"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "TUI application for interacting with CLI commands defined by usage specs"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tuisage`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/mgood/tuisage/compare/v0.1.2...v0.1.3) - 2026-03-23

### Other

- add notes on binary installation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).