### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/mgood/tuisage/compare/v0.1.4...v0.2.0) - 2026-04-20
+
+### Other
+
+- [**breaking**] split code into modular components
+
 ## [0.1.4](https://github.com/mgood/tuisage/compare/v0.1.3...v0.1.4) - 2026-04-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "tuisage"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuisage"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 description = "TUI application for interacting with CLI commands defined by usage specs"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tuisage`: 0.1.4 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/mgood/tuisage/compare/v0.1.4...v0.2.0) - 2026-04-20

### Other

- [**breaking**] split code into modular components
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).