### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/mgood/tuisage/compare/v0.2.0...v0.2.1) - 2026-04-20
+
+### Added
+
+- make select descriptions searchable and right-aligned ([#23](https://github.com/mgood/tuisage/pull/23))
+- add hover highlights to theme picker list ([#22](https://github.com/mgood/tuisage/pull/22))
+- right-click to decrement count flags ([#21](https://github.com/mgood/tuisage/pull/21))
+
 ## [0.2.0](https://github.com/mgood/tuisage/compare/v0.1.4...v0.2.0) - 2026-04-20
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "tuisage"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuisage"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "TUI application for interacting with CLI commands defined by usage specs"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tuisage`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/mgood/tuisage/compare/v0.2.0...v0.2.1) - 2026-04-20

### Added

- make select descriptions searchable and right-aligned ([#23](https://github.com/mgood/tuisage/pull/23))
- add hover highlights to theme picker list ([#22](https://github.com/mgood/tuisage/pull/22))
- right-click to decrement count flags ([#21](https://github.com/mgood/tuisage/pull/21))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).