### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/mgood/tuisage/compare/v0.2.1...v0.2.2) - 2026-07-24
+
+### Other
+
+- link to --usage integrations
+
 ## [0.2.1](https://github.com/mgood/tuisage/compare/v0.2.0...v0.2.1) - 2026-04-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "tuisage"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuisage"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "TUI application for interacting with CLI commands defined by usage specs"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tuisage`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/mgood/tuisage/compare/v0.2.1...v0.2.2) - 2026-09-14

### Added

- reset command options with Ctrl+U ([#28](https://github.com/mgood/tuisage/pull/28))

### Fixed

- show Backspace shortcut in help bar ([#27](https://github.com/mgood/tuisage/pull/27))

### Other

- link to --usage integrations
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).